### PR TITLE
Improve performance

### DIFF
--- a/example/basic/basic.scss
+++ b/example/basic/basic.scss
@@ -28,11 +28,11 @@ $adjectives: (
   )
 );
 
-@include A(emit, true);
-@include A(emit-responsive, true);
+@include A(emit, (important: true, silent: true));
+@include A(emit-responsive, (important: true, silent: true));
 
 .foo {
-  @include A(extend, 'bg', 'greyscale');
+  @include A(extend, 'bg', 'red', (breakpoint: 'small'));
 }
 
 $example-grid-config: (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthology.scss",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "A SCSS library for generating functional CSS patterns that are declarative, theme-able, automatically responsive, and compatible with atomic design!",
   "author": "Ian K Smith <ian.smith@radarrelay.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anthology.scss",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A SCSS library for generating functional CSS patterns that are declarative, theme-able, automatically responsive, and compatible with atomic design!",
   "author": "Ian K Smith <ian.smith@radarrelay.com>",
   "license": "MIT",

--- a/src/scss/_primary-interface.scss
+++ b/src/scss/_primary-interface.scss
@@ -1,7 +1,7 @@
 @mixin A($mixin, $args...) {
   @if not(mixin-exists('__anthology-#{$mixin}'))
   {
-    @error 'Anthology mixin `#{$mixin}` not found.';
+    @error '[anthology] --- Anthology mixin `#{$mixin}` not found.';
   }
 
   @if $mixin == 'configure' { @include __anthology-configure($args...); }
@@ -27,6 +27,6 @@
   }
   @else
   {
-    @error 'Anthology function `#{$function}` not found.'
+    @error '[anthology] --- Anthology function `#{$function}` not found.'
   }
 }

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -5,9 +5,9 @@ $__anthology-config: ();
 $__anthology-config-defaults: (
   'breakpoints': null,
   'separator': '-',
-  'important-tag': '!',
-  'theme-tag': '#',
-  'responsive-tag': '@',
+  'important-tag': '\\\\!',
+  'theme-tag': '\\\\#',
+  'responsive-tag': '\\\\@',
   'grid-prefix': 'grid',
   'grid-area-prefix': 'area',
   'theme-attr': 'data-theme',

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -18,3 +18,8 @@ $__anthology-cache-defaults: (
   'generic': (),
   'responsive': (),
 );
+
+$__anthology-extend-silent: (
+  'generic': false,
+  'responsive': false,
+);

--- a/src/scss/core/_breakpoints.scss
+++ b/src/scss/core/_breakpoints.scss
@@ -10,7 +10,7 @@
 
   @else
   {
-    @error 'Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(breakpoint, ...)`.';
+    @error '[anthology::mixin::breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(breakpoint, ...)`.';
   }
 }
 
@@ -24,7 +24,7 @@
 
   @else
   {
-    @error 'Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(until-breakpoint, ...)`.';
+    @error '[anthology::mixin::until-breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(until-breakpoint, ...)`.';
   }
 }
 

--- a/src/scss/core/_breakpoints.scss
+++ b/src/scss/core/_breakpoints.scss
@@ -10,7 +10,7 @@
 
   @else
   {
-    @error '[anthology::mixin::breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(breakpoint, ...)`.';
+    @error '[anthology::breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(breakpoint, ...)`.';
   }
 }
 
@@ -24,7 +24,7 @@
 
   @else
   {
-    @error '[anthology::mixin::until-breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(until-breakpoint, ...)`.';
+    @error '[anthology::until-breakpoint] --- Breakpoint `#{$point}` is not registered by `A(configure, ...)`. Please register all breakpoints before using `A(until-breakpoint, ...)`.';
   }
 }
 

--- a/src/scss/core/_configure.scss
+++ b/src/scss/core/_configure.scss
@@ -20,7 +20,7 @@
       // "default" is reserved.
       @if $breakpoint == 'default'
       {
-        @error '[anthology::mixin::configure] --- Breakpoints cannot be named `default`.';
+        @error '[anthology::configure] --- Breakpoints cannot be named `default`.';
       }
 
       $__anthology-cache-defaults: A(map-set,
@@ -31,6 +31,15 @@
 
     }
 
+    $escaped-config-keys: ('separator', 'important-tag', 'theme-tag', 'responsive-tag', 'grid-prefix', 'grid-area-prefix', 'theme-attr');
+    @each $config-key, $value in $config
+    {
+      @if A(list-contains, $escaped-config-keys, $config-key)
+      {
+        $config: A(map-set, $config, $config-key, A(str-escape, A(map-get, $config,$config-key), 2));
+      }
+    }
+
     // Build global objects
     $__anthology-config: A(map-merge, $__anthology-config-defaults, $config) !global;
     $__anthology-cache: A(map-merge, $__anthology-cache-defaults, $__anthology-cache) !global;
@@ -38,7 +47,7 @@
   }
   @else
   {
-    @warn '[anthology::mixin::configure] --- `A(configure, ...)` should be included only once per Anthology-generated stylesheet.';
+    @warn '[anthology::configure] --- `A(configure, ...)` should be included only once per Anthology-generated stylesheet.';
   }
 
 }

--- a/src/scss/core/_configure.scss
+++ b/src/scss/core/_configure.scss
@@ -17,6 +17,12 @@
     @each $breakpoint, $value in map-get($config, 'breakpoints')
     {
 
+      // "default" is reserved.
+      @if $breakpoint == 'default'
+      {
+        @error '[anthology::mixin::configure] --- Breakpoints cannot be named `default`.';
+      }
+
       $__anthology-cache-defaults: A(map-set,
         $__anthology-cache-defaults,
         ('responsive', $breakpoint),
@@ -32,7 +38,7 @@
   }
   @else
   {
-    @warn '`A(configure, ...)` should be included only once per Anthology-generated stylesheet.';
+    @warn '[anthology::mixin::configure] --- `A(configure, ...)` should be included only once per Anthology-generated stylesheet.';
   }
 
 }

--- a/src/scss/core/_define.scss
+++ b/src/scss/core/_define.scss
@@ -12,8 +12,10 @@
 /// @param {List} $options.themes - A list of themes to generate selectors for.
 @mixin __anthology-define($shorthand, $property, $values, $options: ())
 {
-  // Ensure `set-config(...)` has been included prior.
-  @include __anthology-validate-config-is-ready();
+  // Ensure `A(configure, ...)` has been included prior.
+  @if not $__anthology-config-is-ready {
+    @error '[anthology::mixin::define] --- Before defining your own functional properties, call `@include A(configure...);`.';
+  }
 
   // Merge default options
   $options: A(define-options, $options);

--- a/src/scss/core/_define.scss
+++ b/src/scss/core/_define.scss
@@ -60,7 +60,7 @@
         // Throw if breakpoint key is invalid.
         @else
         {
-          @error "Invalid breakpoint key: #{$breakpoint}. Choose one of: #{map-keys(map-get($__anthology-cache, 'responsive'))}, or default.";
+          @error "[anthology::mixin::define] --- Invalid breakpoint key: #{$breakpoint}. Choose one of: #{map-keys(map-get($__anthology-cache, 'responsive'))}, or default.";
         }
 
       }

--- a/src/scss/core/_define.scss
+++ b/src/scss/core/_define.scss
@@ -14,7 +14,7 @@
 {
   // Ensure `A(configure, ...)` has been included prior.
   @if not $__anthology-config-is-ready {
-    @error '[anthology::mixin::define] --- Before defining your own functional properties, call `@include A(configure...);`.';
+    @error '[anthology::define] --- Before defining your own functional properties, call `@include A(configure...);`.';
   }
 
   // Merge default options
@@ -62,7 +62,7 @@
         // Throw if breakpoint key is invalid.
         @else
         {
-          @error "[anthology::mixin::define] --- Invalid breakpoint key: #{$breakpoint}. Choose one of: #{map-keys(map-get($__anthology-cache, 'responsive'))}, or default.";
+          @error "[anthology::define] --- Invalid breakpoint key: #{$breakpoint}. Choose one of: #{map-keys(map-get($__anthology-cache, 'responsive'))}, or default.";
         }
 
       }

--- a/src/scss/core/_emit.scss
+++ b/src/scss/core/_emit.scss
@@ -52,7 +52,7 @@
 
   @if length(map-get($__anthology-cache, 'generic')) == 0
   {
-    @warn '[anthology::mixin::emit] --- Nothing to emit';
+    @warn '[anthology::emit] --- Nothing to emit';
   }
 
   $__anthology-extend-silent: A(map-set, $__anthology-extend-silent, ('generic'), $silent) !global;
@@ -122,7 +122,7 @@
 
   @if not map-get($__anthology-config, 'breakpoints')
   {
-    @warn '[anthology::mixin::emit-responsive] --- Responsive breakpoints are not configured. Make sure to call `@include A(configure, ( 'breakpoints': (...) ) );`';
+    @warn '[anthology::emit-responsive] --- Responsive breakpoints are not configured. Make sure to call `@include A(configure, ( 'breakpoints': (...) ) );`';
   }
 
   $__anthology-extend-silent: A(map-set, $__anthology-extend-silent, ('responsive'), $silent) !global;

--- a/src/scss/core/_emit.scss
+++ b/src/scss/core/_emit.scss
@@ -12,9 +12,9 @@
 }
 
 // Performs the actual CSS generation for all combinations of selectors with a given `$shorthand` and `$adjective`.
-@mixin __anthology-do-emit($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important)
+@mixin __anthology-do-emit($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important, $silent)
 {
-  $full-selector-args: ($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important);
+  $full-selector-args: ($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important, $silent);
 
   @if $important
   {
@@ -38,14 +38,24 @@
 /// Emits non-responsive rules. Emitted properties are flushed afterwards.
 ///
 /// @param {Bool} $important - Whether to emit '!important' versions of the rules [default: false].
-@mixin __anthology-emit($important: false)
+@mixin __anthology-emit($options: ())
 {
+  // Merge default options
+  $options: A(emit-options, $options);
+
+  // Unpack options
+  $important: A(map-get, $options, 'important');
+  $silent: A(map-get, $options, 'silent');
+  $flush-cache: A(map-get, $options, 'flush-cache');
+
   @include __anthology-emit-metadata();
 
   @if length(map-get($__anthology-cache, 'generic')) == 0
   {
-    @warn 'Nothing to emit';
+    @warn '[anthology::mixin::emit] --- Nothing to emit';
   }
+
+  $__anthology-extend-silent: A(map-set, $__anthology-extend-silent, ('generic'), $silent) !global;
 
   @each $shorthand, $adjectives in map-get($__anthology-cache, 'generic')
   {
@@ -58,31 +68,64 @@
       $pseudos: nth($helper, 4);
       $themes: nth($helper, 5);
 
-      // Emit without `!important`
-      @include __anthology-do-emit($shorthand, $adjective, $property, $value, null, $pseudos, $themes, false);
+      $should-emit-important: $important and $important-override;
 
-      // Emit with `!important`
-      @if $important and $important-override
+      @include __anthology-do-emit(
+        $shorthand: $shorthand,
+        $adjective: $adjective,
+        $property: $property,
+        $value: $value,
+        $breakpoint: null,
+        $pseudos: $pseudos,
+        $themes: $themes,
+        $important: false,
+        $silent: $silent,
+      );
+
+      @if $should-emit-important
       {
-        @include __anthology-do-emit($shorthand, $adjective, $property, $value, null, $pseudos, $themes, true);
+        @include __anthology-do-emit(
+          $shorthand: $shorthand,
+          $adjective: $adjective,
+          $property: $property,
+          $value: $value,
+          $breakpoint: null,
+          $pseudos: $pseudos,
+          $themes: $themes,
+          $important: true,
+          $silent: $silent,
+        );
       }
     }
   }
 
-  $__anthology-cache: A(flush-cache, 'generic') !global;
+  @if $flush-cache
+  {
+    $__anthology-cache: A(flush-cache, 'generic') !global;
+  }
 }
 
 /// Emits responsive, media query efficient helpers. Emitted properties are flushed afterwards.
 ///
 /// @param {Bool} $important - Whether to emit '!important' versions of the rules [default: false].
-@mixin __anthology-emit-responsive($important: false)
+@mixin __anthology-emit-responsive($options: ())
 {
+  // Merge default options
+  $options: A(emit-options, $options);
+
+  // Unpack options
+  $important: A(map-get, $options, 'important');
+  $silent: A(map-get, $options, 'silent');
+  $flush-cache: A(map-get, $options, 'flush-cache');
+
   @include __anthology-emit-metadata();
 
   @if not map-get($__anthology-config, 'breakpoints')
   {
-    @warn 'Responsive breakpoints are not configured. Make sure to run `@include set-config( ( 'breakpoints': (...) ) );';
+    @warn '[anthology::mixin::emit-responsive] --- Responsive breakpoints are not configured. Make sure to call `@include A(configure, ( 'breakpoints': (...) ) );`';
   }
+
+  $__anthology-extend-silent: A(map-set, $__anthology-extend-silent, ('responsive'), $silent) !global;
 
   @each $breakpoint, $shorthands in map-get($__anthology-cache, 'responsive')
   {
@@ -90,45 +133,52 @@
     {
       @each $shorthand, $adjectives in $shorthands
       {
-        @each $adjective, $helper in $adjectives
+        @each $adjective, $attributes in $adjectives
         {
-          // Unpack helper
-          $property: nth($helper, 1);
-          $value: nth($helper, 2);
-          $important-override: nth($helper, 3);
-          $include-responsive-tag: nth($helper, 4);
-          $pseudos: nth($helper, 5);
-          $themes: nth($helper, 6);
+          // Unpack attributes
+          $property: nth($attributes, 1);
+          $value: nth($attributes, 2);
+          $important-override: nth($attributes, 3);
+          $include-responsive-tag: nth($attributes, 4);
+          $pseudos: nth($attributes, 5);
+          $themes: nth($attributes, 6);
 
-          // Emit without responsive tag (dynamically responsive values)
-          @if not($include-responsive-tag)
+          $should-emit-breakpoint-tag: if($include-responsive-tag, $breakpoint, null);
+          $should-emit-important: $important and $important-override;
+
+          @include __anthology-do-emit(
+            $shorthand: $shorthand,
+            $adjective: $adjective,
+            $property: $property,
+            $value: $value,
+            $breakpoint: $should-emit-breakpoint-tag,
+            $pseudos: $pseudos,
+            $themes: $themes,
+            $important: false,
+            $silent: $silent,
+          );
+
+          @if $should-emit-important
           {
-            // Emit without `!important`;
-            @include __anthology-do-emit($shorthand, $adjective, $property, $value, null, $pseudos, $themes, false);
-
-            // Emit with `!important`
-            @if $important and $important-override
-            {
-              @include __anthology-do-emit($shorthand, $adjective, $property, $value, null, $pseudos, $themes, true);
-            }
-          }
-
-          // Emit with responsive tag
-          @else
-          {
-            // Emit without `!important`
-            @include __anthology-do-emit($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, false);
-
-            // Emit with `!important`
-            @if $important and $important-override
-            {
-              @include __anthology-do-emit($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, true);
-            }
+            @include __anthology-do-emit(
+              $shorthand: $shorthand,
+              $adjective: $adjective,
+              $property: $property,
+              $value: $value,
+              $breakpoint: $should-emit-breakpoint-tag,
+              $pseudos: $pseudos,
+              $themes: $themes,
+              $important: true,
+              $silent: $silent,
+            );
           }
         }
       }
     }
   }
 
-  $__anthology-cache: A(flush-cache, 'responsive') !global;
+  @if $flush-cache
+  {
+    $__anthology-cache: A(flush-cache, 'responsive') !global;
+  }
 }

--- a/src/scss/core/_extend.scss
+++ b/src/scss/core/_extend.scss
@@ -11,6 +11,11 @@
 /// @param {Bool} $options.important - Whether to extend with `!important`.
 @mixin __anthology-extend($args...)
 {
+  // Ensure `A(configure, ...)` has been included prior.
+  @if not $__anthology-config-is-ready {
+    @error '[anthology::mixin::extend] --- Before extending functional properties, call `@include A(configure...);`.';
+  }
+
   $shorthand: nth($args, 1);
 
   @if type-of($shorthand) == list

--- a/src/scss/core/_extend.scss
+++ b/src/scss/core/_extend.scss
@@ -27,8 +27,18 @@
     $raw-options: if(length($args) > 2, nth($args, 3), ());
     $options: A(single-selector-options, $raw-options);
 
-    $raw-selector: A(str-escape, A(raw-selector, $shorthand, $adjective, $options));
+    $should-extend-silent: if(
+      A(map-get, $options, 'breakpoint'),
+      A(map-get, $__anthology-extend-silent, 'responsive'),
+      A(map-get, $__anthology-extend-silent, 'generic'),
+    );
 
-    @extend #{'.#{$raw-selector}'};
+    $selector: if(
+      $should-extend-silent,
+      A(silent-selector, $shorthand, $adjective, $options),
+      '.#{A(str-escape, A(raw-selector, $shorthand, $adjective, $options))}'
+    );
+
+    @extend #{'#{$selector}'};
   }
 }

--- a/src/scss/core/_extend.scss
+++ b/src/scss/core/_extend.scss
@@ -13,7 +13,7 @@
 {
   // Ensure `A(configure, ...)` has been included prior.
   @if not $__anthology-config-is-ready {
-    @error '[anthology::mixin::extend] --- Before extending functional properties, call `@include A(configure...);`.';
+    @error '[anthology::extend] --- Before extending functional properties, call `@include A(configure...);`.';
   }
 
   $shorthand: nth($args, 1);
@@ -38,10 +38,14 @@
       A(map-get, $__anthology-extend-silent, 'generic'),
     );
 
+    $raw-selector: A(raw-selector, $shorthand, $adjective, $options);
+    // We need to dilute the string escapes by half.
+    $raw-selector: A(str-replace, $raw-selector, '\\\\', '\\');
+
     $selector: if(
       $should-extend-silent,
-      A(silent-selector, $shorthand, $adjective, $options),
-      '.#{A(str-escape, A(raw-selector, $shorthand, $adjective, $options))}'
+      '%#{$raw-selector}',
+      '.#{$raw-selector}',
     );
 
     @extend #{'#{$selector}'};

--- a/src/scss/core/_grid.scss
+++ b/src/scss/core/_grid.scss
@@ -70,7 +70,7 @@ $grid-areas: ();
       // Throw if breakpoint key is invalid.
       @else
       {
-        @error "Invalid breakpoint key: `#{$breakpoint}`. Choose one of: #{map-keys(map-get($__anthology-config, 'breakpoints'))}, or default.";
+        @error "[anthology::mixin::grid] --- Invalid breakpoint key: `#{$breakpoint}`. Choose one of: #{map-keys(map-get($__anthology-config, 'breakpoints'))}, or default.";
       }
 
     }

--- a/src/scss/core/_grid.scss
+++ b/src/scss/core/_grid.scss
@@ -70,7 +70,7 @@ $grid-areas: ();
       // Throw if breakpoint key is invalid.
       @else
       {
-        @error "[anthology::mixin::grid] --- Invalid breakpoint key: `#{$breakpoint}`. Choose one of: #{map-keys(map-get($__anthology-config, 'breakpoints'))}, or default.";
+        @error "[anthology::grid] --- Invalid breakpoint key: `#{$breakpoint}`. Choose one of: #{map-keys(map-get($__anthology-config, 'breakpoints'))}, or default.";
       }
 
     }

--- a/src/scss/lib/_map.scss
+++ b/src/scss/lib/_map.scss
@@ -75,7 +75,7 @@
   // Warn the user we will be overriding it with $value
   @if type-of(nth($keys, -1)) == "map"
   {
-    @warn "[anthology::function::map-set] --- The last key you specified is a map; it will be overrided with `#{$value}`.";
+    @warn "[anthology::map-set] --- The last key you specified is a map; it will be overrided with `#{$value}`.";
   }
 
   // If $keys is a single key
@@ -141,7 +141,7 @@
   {
     @if not(A(map-has-key, $map, $key))
     {
-      @warn '[anthology::function::map-reorder-keys] --- Key `#{$key}` does not exist in the provided map. Skipping it.';
+      @warn '[anthology::map-reorder-keys] --- Key `#{$key}` does not exist in the provided map. Skipping it.';
     }
 
     $result: A(map-set, $result, ($key), A(map-get, $map, ($key)));

--- a/src/scss/lib/_map.scss
+++ b/src/scss/lib/_map.scss
@@ -75,7 +75,7 @@
   // Warn the user we will be overriding it with $value
   @if type-of(nth($keys, -1)) == "map"
   {
-    @warn "The last key you specified is a map; it will be overrided with `#{$value}`.";
+    @warn "[anthology::function::map-set] --- The last key you specified is a map; it will be overrided with `#{$value}`.";
   }
 
   // If $keys is a single key

--- a/src/scss/lib/_map.scss
+++ b/src/scss/lib/_map.scss
@@ -132,3 +132,28 @@
 
   @return $result;
 }
+
+@function __anthology-map-reorder-keys($map, $ordered-keys)
+{
+  $result: ();
+
+  @each $key in $ordered-keys
+  {
+    @if not(A(map-has-key, $map, $key))
+    {
+      @warn '[anthology::function::map-reorder-keys] --- Key `#{$key}` does not exist in the provided map. Skipping it.';
+    }
+
+    $result: A(map-set, $result, ($key), A(map-get, $map, ($key)));
+  }
+
+  @each $key, $value in $map
+  {
+    @if (not(A(list-contains, $ordered-keys, $key)))
+    {
+      $result: A(map-set, $result, ($key), A(map-get, $map, ($key)));
+    }
+  }
+
+  @return $result;
+}

--- a/src/scss/lib/_selectors.scss
+++ b/src/scss/lib/_selectors.scss
@@ -39,20 +39,13 @@
   {
     @if not A(str-starts-with, $pseudo, ':') and not A(str-starts-with, $pseudo, '::')
     {
-      @error '[anthology::function::raw-selector] --- Expected a pseudo-class or pseudo-element, received `#{$pseudo}`.';
+      @error '[anthology::raw-selector] --- Expected a pseudo-class or pseudo-element, received `#{$pseudo}`.';
     }
 
-    $with-pseudo: '#{$pseudo}';
+    $with-pseudo: '\\\\#{$pseudo}';
     $result: '#{$result}#{$sep}#{$with-pseudo}';
   }
 
-  @return $result;
-}
-
-@function __anthology-silent-selector($shorthand, $adjective, $options)
-{
-  $raw-selector: A(str-escape, A(raw-selector, $shorthand, $adjective, $options), 1);
-  $result: '%#{$raw-selector}';
   @return $result;
 }
 
@@ -72,9 +65,12 @@
 
   // Build selector
   $theme-designation-selector: '[#{$theme-attr}~="#{$theme}"]';
-  $raw-selector: A(str-escape, A(raw-selector, $shorthand, $adjective, $options), 2);
-  $class-indicator: if($silent, '%', '.');
-  $result: '#{$class-indicator}#{$raw-selector}';
+  $raw-selector: A(raw-selector, $shorthand, $adjective, $options);
+  $result: if(
+    $silent,
+    '%#{$raw-selector}',
+    '.#{$raw-selector}',
+  );
 
   @if $theme
   {

--- a/src/scss/lib/_selectors.scss
+++ b/src/scss/lib/_selectors.scss
@@ -1,5 +1,5 @@
-// Generates a raw string for composing into usable selectors.
-@function __anthology-raw-selector($shorthand, $adjective, $options: ())
+// Generates a raw selector string.
+@function __anthology-raw-selector($shorthand, $adjective, $options)
 {
   // Get config properties
   $sep: A(map-get, $__anthology-config, 'separator');
@@ -39,7 +39,7 @@
   {
     @if not A(str-starts-with, $pseudo, ':') and not A(str-starts-with, $pseudo, '::')
     {
-      @error 'Expected a pseudo-class or pseudo-element, received `#{$pseudo}`.';
+      @error '[anthology::function::raw-selector] --- Expected a pseudo-class or pseudo-element, received `#{$pseudo}`.';
     }
 
     $with-pseudo: '#{$pseudo}';
@@ -49,8 +49,15 @@
   @return $result;
 }
 
-// Generates a usable selector that targets the class attribute, like this: `[class~="shorthand-adjective-*"]`.
-@function __anthology-compound-selector($shorthand, $adjective, $options: ())
+@function __anthology-silent-selector($shorthand, $adjective, $options)
+{
+  $raw-selector: A(str-escape, A(raw-selector, $shorthand, $adjective, $options), 1);
+  $result: '%#{$raw-selector}';
+  @return $result;
+}
+
+// Generates a usable selector that targets themes and pseudo-elements/pseudo-classes.
+@function __anthology-compound-selector($shorthand, $adjective, $options, $silent)
 {
   $theme-attr: A(map-get, $__anthology-config, 'theme-attr');
 
@@ -66,7 +73,8 @@
   // Build selector
   $theme-designation-selector: '[#{$theme-attr}~="#{$theme}"]';
   $raw-selector: A(str-escape, A(raw-selector, $shorthand, $adjective, $options), 2);
-  $result: '.#{$raw-selector}';
+  $class-indicator: if($silent, '%', '.');
+  $result: '#{$class-indicator}#{$raw-selector}';
 
   @if $theme
   {
@@ -90,9 +98,9 @@
 }
 
 // Generates all combinations of class attribute selectors for the given arguments.
-@function __anthology-full-selector($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important)
+@function __anthology-full-selector($shorthand, $adjective, $property, $value, $breakpoint, $pseudos, $themes, $important, $silent)
 {
-  $result: A(compound-selector, $shorthand, $adjective, ('important': $important, 'breakpoint': $breakpoint));
+  $result: A(compound-selector, $shorthand, $adjective, ('important': $important, 'breakpoint': $breakpoint), $silent);
 
   @if $pseudos
   {
@@ -104,7 +112,7 @@
       {
         @each $theme in $themes
         {
-          $selector: A(compound-selector, $shorthand, $adjective, ('theme': $theme, 'pseudo': $pseudo, 'important': $important, 'breakpoint': $breakpoint));
+          $selector: A(compound-selector, $shorthand, $adjective, ('theme': $theme, 'pseudo': $pseudo, 'important': $important, 'breakpoint': $breakpoint), $silent);
           @if not A(str-contains, $result, $selector)
           {
             $result: '#{$result}, #{$selector}';
@@ -112,7 +120,7 @@
         }
       }
 
-      $selector: A(compound-selector, $shorthand, $adjective, ('pseudo': $pseudo, 'important': $important, 'breakpoint': $breakpoint));
+      $selector: A(compound-selector, $shorthand, $adjective, ('pseudo': $pseudo, 'important': $important, 'breakpoint': $breakpoint), $silent);
       @if not A(str-contains, $result, $selector)
       {
         $result: '#{$result}, #{$selector}';
@@ -124,7 +132,7 @@
   {
     @each $theme in $themes
     {
-      $selector: A(compound-selector, $shorthand, $adjective, ('theme': $theme, 'important': $important, 'breakpoint': $breakpoint));
+      $selector: A(compound-selector, $shorthand, $adjective, ('theme': $theme, 'important': $important, 'breakpoint': $breakpoint), $silent);
       @if not A(str-contains, $result, $selector)
       {
         $result: '#{$result}, #{$selector}';

--- a/src/scss/lib/_string.scss
+++ b/src/scss/lib/_string.scss
@@ -55,6 +55,16 @@
   @return '#{$values}';
 }
 
+@function __anthology-str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + A(str-replace, str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}
+
 $__anthology-escape-chars: (
   '!', '"', '#', '$', '%','&', "'", '(', ')', '*',
 
@@ -74,38 +84,10 @@ $__anthology-escape-chars: (
     $escape: '#{$escape}\\';
   }
 
-  // If $result starts with a number, escape it.
-  @for $i from 0 through 9
-  {
-    @if A(str-starts-with, $result, quote($i))
-    {
-      $result: '#{$escape}#{$result}';
-    }
-  }
-
-  // If $result starts with a dash or underscore, escape it.
-  @if A(str-starts-with, $result, '-') or A(str-starts-with, $result, '_')
-  {
-    $result: '#{$escape}#{$result}';
-  }
-
   // Escape the listed characters
-  @each $c in $__anthology-escape-chars {
-    $split-string: A(str-split, $result, $c);
-
-    @for $i from 1 through length($split-string)
-    {
-      $part: nth($split-string, $i);
-
-      @if $i == 1
-      {
-        $result: $part;
-      }
-      @else
-      {
-        $result: '#{$result}#{$escape}#{$c}#{$part}';
-      }
-    }
+  @each $c in $__anthology-escape-chars
+  {
+    $result: A(str-replace, $result, $c,'#{$escape}#{$c}');
   }
 
   @return $result;

--- a/src/scss/lib/_utils.scss
+++ b/src/scss/lib/_utils.scss
@@ -1,7 +1,7 @@
 // Ensure that `set-config(...)` has been included at least once.
 @mixin __anthology-validate-config-is-ready() {
   @if not $__anthology-config-is-ready {
-    @error 'Before defining your own functional properties, run `@include anth-config(...);`.';
+    @error '[anthology::mixin::validate-config-is-ready] --- Before defining your own functional properties, call `@include A(configure...);`.';
   }
 }
 
@@ -27,7 +27,7 @@
   );
 }
 
-// Merge default options for `define-properties(...)` mixin.
+// Merge default options for `A(define, ...)` mixin.
 @function __anthology-define-options($options: ()) {
   @return A(map-merge,
     (
@@ -35,6 +35,18 @@
       'responsive': true,
       'pseudos': null,
       'themes': null,
+    ),
+    $options
+  );
+}
+
+// Merge default options for `A(emit, ...)` mixin.
+@function __anthology-emit-options($options: ()) {
+  @return A(map-merge,
+    (
+      'important': false,
+      'silent': false,
+      'flush-cache': true,
     ),
     $options
   );

--- a/src/scss/lib/_utils.scss
+++ b/src/scss/lib/_utils.scss
@@ -1,16 +1,9 @@
-// Ensure that `set-config(...)` has been included at least once.
-@mixin __anthology-validate-config-is-ready() {
-  @if not $__anthology-config-is-ready {
-    @error '[anthology::mixin::validate-config-is-ready] --- Before defining your own functional properties, call `@include A(configure...);`.';
-  }
-}
-
 // Returns the cache with the specified key reset to its default value.
 @function __anthology-flush-cache($cache-key) {
   @return A(map-set,
     $__anthology-cache,
     $cache-key,
-    __anthology-map-get($__anthology-cache-defaults, $cache-key)
+    A(map-get, $__anthology-cache-defaults, $cache-key)
   );
 }
 


### PR DESCRIPTION
- `A(emit, ...)` can now be configured to write placeholder, "silent" classes, instead of actual CSS.
- Improve performance by up to 300% by cleaning up `A(str-escape, ...)` logic.